### PR TITLE
refactor: `AutoFitImage` 컴포넌트의 `css` 구문 제거 후 리팩토링

### DIFF
--- a/src/components/AutoFitImage/AutoFitImage.js
+++ b/src/components/AutoFitImage/AutoFitImage.js
@@ -1,21 +1,12 @@
 import React from 'react';
-import { Image, Dimensions } from 'react-native';
-import { css } from '@emotion/native';
+import { Dimensions } from 'react-native';
+import { Image } from './AutoFitImage.styles';
 
 const AutoFitImage = (props) => {
   const dimensions = Dimensions.get('window');
   const imageHeight = Math.round(dimensions.width);
 
-  return (
-    <Image
-      {...props}
-      style={css`
-        width: 100%;
-        height: ${`${imageHeight}px`};
-      `}
-      resizeMode="contain"
-    />
-  );
+  return <Image {...props} height={imageHeight} resizeMode="contain" />;
 };
 
 export default AutoFitImage;

--- a/src/components/AutoFitImage/AutoFitImage.styles.js
+++ b/src/components/AutoFitImage/AutoFitImage.styles.js
@@ -1,0 +1,6 @@
+import styled from '@emotion/native';
+
+export const Image = styled.Image`
+  width: 100%;
+  height: ${({ height }) => `${height}px`};
+`;


### PR DESCRIPTION
- Emotion을 사용할 때 `css` 구문을 사용하지 않고 `styled`를 사용하기로 한 결정 사항을 반영함