### PR TITLE
[Detail] 카페 상세 정보 페이지에서 지도가 보이도록 구현

### DIFF
--- a/src/components/DetailInfo/DetailLocation.js
+++ b/src/components/DetailInfo/DetailLocation.js
@@ -1,14 +1,36 @@
+import { css } from '@emotion/native';
 import React from 'react';
-import { Text } from 'react-native';
+import MapView, { PROVIDER_GOOGLE } from 'react-native-maps';
+import MapMarker from '~/components/MapMarker/MapMarker';
 import { DetailLocationWrapper, DetailLocationBox, Title, LocationMap } from './DetailLocation.styles';
+import MapPickerSelectImage from '~/assets/icons/icon_mappicker_select.png';
 
-const DetailLocation = () => {
+const DetailLocation = ({ latitude, longitude }) => {
   return (
     <DetailLocationWrapper>
       <DetailLocationBox>
         <Title>위치</Title>
         <LocationMap>
-          <Text>Location</Text>
+          <MapView
+            cacheEnabled={true}
+            loadingEnabled={true}
+            moveOnMarkerPress={false}
+            pitchEnabled={false}
+            rotateEnabled={false}
+            zoomEnabled={false}
+            scrollEnabled={false}
+            provider={PROVIDER_GOOGLE}
+            style={css`
+              flex: 1;
+            `}
+            initialRegion={{
+              latitude: latitude,
+              longitude: longitude,
+              latitudeDelta: 0.005,
+              longitudeDelta: 0.005,
+            }}>
+            <MapMarker coordinate={{ latitude, longitude }} image={MapPickerSelectImage} tracksViewChanges={true} stopPropagation={true} />
+          </MapView>
         </LocationMap>
       </DetailLocationBox>
     </DetailLocationWrapper>

--- a/src/screens/Detail/Detail.js
+++ b/src/screens/Detail/Detail.js
@@ -138,6 +138,8 @@ const Detail = ({ userId, route, navigation: { goBack } }) => {
     return <LoadingBar />;
   }
 
+  const [cafeLongitude, cafeLatitude] = detailCafeData.data.location.coordinates;
+
   return (
     <>
       <Header
@@ -166,7 +168,7 @@ const Detail = ({ userId, route, navigation: { goBack } }) => {
         <DetailTitle title={detailCafeData.data.name} distance={`${Math.floor(detailCafeData.data.dist.calculated)}m`} tags={detailCafeData.data.tags} />
         <ImageGrid title={detailCafeData.data.name} distance={`${Math.floor(detailCafeData.data.dist.calculated)}m`} tags={detailCafeData.data.tags} />
         <DetailInfo address={detailCafeData.data.parcel_addr} phone={detailCafeData.data.phone} />
-        <DetailLocation />
+        <DetailLocation latitude={cafeLatitude} longitude={cafeLongitude} />
         <TagList tags={detailCafeData.data.tags} preferTags={preferredTags} onSetTagsModal={handleSetTagsModal} />
         <CommentList
           comments={comments}


### PR DESCRIPTION
## 기능
- [x] 카페 상세 정보 페이지에서 지도를 확인할 수 있다,
  - 지도는 움직이거나 확대/축소할 수 없다.

## 기타
- 지도를 터치했을 때 다른 지도 앱으로 리다이렉트하거나, 사용자가 자세한 위치를 확인할 수 있는 UX 구현이 필요해보임